### PR TITLE
Major rewrite of the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# vim swaps
+.*.swp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Backend.AI Client for Javascript
+
+## Install
+
+```console
+$ npm install backend.ai-client
+```
+
+## Usage
+
+TypeScript:
+```typescript
+import * as ai from 'backend.ai-client';
+
+let config = new ai.backend.ClientConfig.createFromEnv();
+let client = new ai.backend.Client(config);
+```
+
+CommonJS-style:
+```javascript
+const ai = require('backend.ai-client');
+
+let config = new ai.backend.ClientConfig.createFromEnv();
+let client = new ai.backend.Client(config);
+```
+
+When creating `ClientConfig` object, you can manually pass `accessKey`,
+`secretKey`, and optional `endpoint` arguments.
+
+All API functions return a promise that resolves into a JSON object
+in both success and failures.
+
+Success JSON objects contains different fields API by API.
+Please check out [our official documentation](http://docs.backend.ai).
+
+Failure JSON objects contains a `title` attribute and other fields
+describing the error information.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backend.AI Client for Javascript
+# Backend.AI Client for Javascript (ES6+)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ let client = new ai.backend.Client(config);
 
 When creating `ClientConfig` object, you can manually pass `accessKey`,
 `secretKey`, and optional `endpoint` arguments.
+The environment variables are:
+* `BACKEND_ACCESS_KEY`
+* `BACKEND_SECRET_KEY`
+* `BACKEND_ENDPOINT` (optional, defaults to `https://api.backend.ai`)
 
 All API functions return a promise that resolves into a JSON object
 when success and rejects with a pair of error type and error message

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TypeScript:
 ```typescript
 import * as ai from 'backend.ai-client';
 
-let config = new ai.backend.ClientConfig.createFromEnv();
+let config = ai.backend.ClientConfig.createFromEnv();
 let client = new ai.backend.Client(config);
 ```
 
@@ -20,7 +20,7 @@ CommonJS-style:
 ```javascript
 const ai = require('backend.ai-client');
 
-let config = new ai.backend.ClientConfig.createFromEnv();
+let config = ai.backend.ClientConfig.createFromEnv();
 let client = new ai.backend.Client(config);
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Backend.AI Client for Javascript (ES6+)
 
+## Requirements
+
+This client SDK runs on ES6-compatible Javascript runtimes with async/await supports
+such as NodeJS 7+ and modern web browsers released since 2017.
+
 ## Install
 
 ```console
@@ -31,28 +36,34 @@ The environment variables are:
 * `BACKEND_SECRET_KEY`
 * `BACKEND_ENDPOINT` (optional, defaults to `https://api.backend.ai`)
 
-All API functions return a promise that resolves into a JSON object
-when success and rejects with a pair of error type and error message
-if failed.
+All API functions return a promise that resolves into a parsed object
+when success according to server-provided `Content-Type` and rejects with an
+object with `type` and `message` attributes if failed.
 
 ```javascript
-client.create('python:latest', 'my-session-id')
+client.createIfNotExists('python:latest', 'my-session-id')
 .then(response => {
-    console.log(`my session is created: ${response.kernelId}`);
-}).catch((errorType, errorMsg) => {
-    console.log(`session creation failed: ${errorMsg}`);
+  console.log(`my session is created: ${response.kernelId}`);
+}).catch(err => {
+  switch (err.type) {
+  case ai.backend.Client.ERR_SERVER:
+    console.log(`session creation failed: ${err.message}`);
+    break;
+  default:
+    console.log(`request/response failed: ${err.message}`);
+  }
 });
 ```
 
-JSON objects returned with success contain different fields API by API.
+The result objects returned with success has different formats API by API.
 Please check out [our official documentation](http://docs.backend.ai).
 
-`errorType` is one of the following values:
+`err.type` is one of the following values:
 
 * `ai.backend.Client.ERR_SERVER`: The server responded with failure.
-  In this case, `errorMsg` includes HTTP status and additional error information
+  In this case, `err.message` includes HTTP status and additional error information
   returned by the API server.
 * `ai.backend.Client.ERR_RESPONSE`: An error occurred while reading the response.
-  `errorMsg` includes an exception value passed from your Javascript runtime.
+  `err.message` includes an exception value passed from your Javascript runtime.
 * `ai.backend.Client.ERR_REQUEST`: An error occurred while sending the request.
-  `errorMsg` includes an exception value passed from your Javascript runtime.
+  `err.message` includes an exception value passed from your Javascript runtime.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,27 @@ When creating `ClientConfig` object, you can manually pass `accessKey`,
 `secretKey`, and optional `endpoint` arguments.
 
 All API functions return a promise that resolves into a JSON object
-in both success and failures.
+when success and rejects with a pair of error type and error message
+if failed.
 
-Success JSON objects contains different fields API by API.
+```javascript
+client.create('python:latest', 'my-session-id')
+.then(response => {
+    console.log(`my session is created: ${response.kernelId}`);
+}).catch((errorType, errorMsg) => {
+    console.log(`session creation failed: ${errorMsg}`);
+});
+```
+
+JSON objects returned with success contain different fields API by API.
 Please check out [our official documentation](http://docs.backend.ai).
 
-Failure JSON objects contains a `title` attribute and other fields
-describing the error information.
+`errorType` is one of the following values:
+
+* `ai.backend.Client.ERR_SERVER`: The server responded with failure.
+  In this case, `errorMsg` includes HTTP status and additional error information
+  returned by the API server.
+* `ai.backend.Client.ERR_RESPONSE`: An error occurred while reading the response.
+  `errorMsg` includes an exception value passed from your Javascript runtime.
+* `ai.backend.Client.ERR_REQUEST`: An error occurred while sending the request.
+  `errorMsg` includes an exception value passed from your Javascript runtime.

--- a/backend.ai-client.js
+++ b/backend.ai-client.js
@@ -14,20 +14,21 @@ if (typeof fetch === 'undefined') {
 }
 var crypto = require('crypto');
 
-class BackendAIConfig {
+class ClientConfig {
   constructor(accessKey, secretKey, endpoint) {
     // fixed configs with this implementation
     this._apiVersionMajor = 'v2';
     this._apiVersion = 'v2.20170315';
     this._hashType = 'sha256';
     // dynamic configs
-    if (typeof accessKey == 'undefined' || accessKey == null)
+    if (accessKey === undefined || accessKey === null)
       throw 'You must set accessKey.';
-    if (typeof secretKey == 'undefined' || secretKey == null)
-      throw 'You must set accessKey.';
-    if (typeof endpoint == 'undefined' || endpoint == null)
+    if (secretKey === undefined || secretKey === null)
+      throw 'You must set secretKey.';
+    if (endpoint === undefined || endpoint === null)
       endpoint = 'https://api.backend.ai';
     this._endpoint = endpoint;
+    this._endpointHost = endpoint.replace(/^[^:]+:\/\//, '');
     this._accessKey = accessKey;
     this._secretKey = secretKey;
   }
@@ -44,15 +45,19 @@ class BackendAIConfig {
     return this._endpoint;
   }
 
+  get endpointHost() {
+    return this._endpointHost;
+  }
+
   get apiVersion() {
     return this._apiVersion;
   }
 
-  get apiVersionMajor {
+  get apiVersionMajor() {
     return this._apiVersionMajor;
   }
 
-  get hashType {
+  get hashType() {
     return this._hashType;
   }
 
@@ -65,14 +70,20 @@ class BackendAIConfig {
   }
 }
 
-class BackendAIClient {
-  constructor(config) {
+class Client {
+  /**
+   * The client API wrapper.
+   *
+   * @param {BackendAIConfig} config - the API client-side configuration
+   * @param {string} agentSignature - an extra string that will be appended to User-Agent headers when making API requests
+   */
+  constructor(config, agentSignature) {
     this.code = null;
-    this.signKey = null;
     this.kernelId = null;
     this.kernelType = null;
-    this.clientVersion = '0.1.5';  // TODO: read from package.json?
-    if (typeof config == 'undefined') {
+    this.clientVersion = '0.2.0';  // TODO: read from package.json?
+    this.agentSignature = agentSignature;
+    if (config === undefined) {
       this._config = BackendAIConfig.createFromEnv();
     } else {
       this._config = config;
@@ -82,52 +93,87 @@ class BackendAIClient {
   getAPIversion() {
     let rqst = this.newUnsignedRequest('GET', '/', null);
     return fetch(rqst.uri, rqst)
-    .then( function(response) {
+    .then( response => {
       if (response.version) {
-        console.log(`API version: ${response.version}`);
         return response.version;
       }
       return true;
     });
   }
 
-  createKernel(kernelType, clientSessionToken) {
-    if (typeof clientSessionToken == 'undefined')
-      clientSessionToken = "backend-ai-live-code-runner";
-    let requestBody = {
+  /**
+   * Create a compute session if the session for the given sessionId does not exists.
+   * It returns the information for the existing session otherwise, without error.
+   *
+   * @param {string} kernelType - the kernel type (usually language runtimes)
+   * @param {string} sessionId - user-defined session ID
+   */
+  createIfNotExists(kernelType, sessionId) {
+    if (sessionId === undefined)
+      sessionId = "backend-ai-live-code-runner";
+    let params = {
       "lang": kernelType,
-      "clientSessionToken": clientSessionToken,
-      "resourceLimits": {
-        "maxMem": 0,
-        "timeout": 0
-      }
+      "clientSessionToken": sessionId,
     };
-    let rqst = this.newSignedRequest('POST', '/kernel/create', requestBody);
+    let rqst = this.newSignedRequest('POST', '/kernel/create', params);
     return fetch(rqst.uri, rqst);
+  }
+
+  /**
+   * Terminate and destroy the kernel session.
+   *
+   * @param {string} sessionId - the sessionId given when created
+   */
+  destroy(sessionId) {
+    let rqst = this.newSignedRequest('DELETE', `/kernel/${sessionId}`, null);
+    return fetch(rqst.uri, rqst);
+  }
+
+  /**
+   * Restart the kernel session keeping its work directory and volume mounts.
+   *
+   * @param {string} sessionId - the sessionId given when created
+   */
+  restart(sessionId) {
+    let rqst = this.newSignedRequest('PATCH', `/kernel/${sessionId}`, null);
+    return fetch(rqst.uri, rqst);
+  }
+
+  createKernel(kernelType) {
+    // legacy alias
+    return this.createIfNotExists(kernelType);
   }
 
   destroyKernel(kernelId) {
-    let rqst = this.newSignedRequest('DELETE', `/kernel/${kernelId}`, null);
-    return fetch(rqst.uri, rqst);
+    // legacy alias
+    return this.destroy(kernelId);
   }
 
-  restartKernel(kernelId) {
-    let rqst = this.newSignedRequest('PATCH', `/kernel/${kernelId}`, null);
-    return fetch(rqst.uri, rqst);
+  refreshKernel(kernelId) {
+    // legacy alias
+    return this.restartKernel(kernelId);
   }
 
   // TODO: interrupt
 
   // TODO: auto-complete
 
-  execute(kernelId, runId, mode, code, opts) {
-    let requestBody = {
+  /**
+   * Execute a code snippet or schedule batch-mode executions.
+   *
+   * @param {string} sessionId - the sessionId given when created
+   * @param {string} runId - a random ID to distinguish each continuation until finish (the length must be between 8 to 64 bytes inclusively)
+   * @param {string} mode - either "query", "batch", "input", or "continue"
+   * @param {string} opts - an optional object specifying additional configs such as batch-mode build/exec commands
+   */
+  execute(sessionId, runId, mode, code, opts) {
+    let params = {
       "mode": mode,
       "code": code,
       "runId": runId,
       "opts": opts,
     };
-    let rqst = this.newSignedRequest('POST', `/kernel/${kernelId}`, requestBody);
+    let rqst = this.newSignedRequest('POST', `/kernel/${sessionId}`, params);
     return fetch(rqst.uri, rqst);
   }
 
@@ -136,26 +182,39 @@ class BackendAIClient {
     return this.execute(kernelId, runId, mode, code, {});
   }
 
+  mangleUserAgentSignature() {
+    let uaSig = this.clientVersion
+                + (this.agentSignature ? ('; ' + this.agentSignature) : '');
+    return uaSig;
+  }
+
+  /**
+   * Generate a RequestInfo object that can be passed to fetch() API,
+   * which includes a properly signed header with the configured auth information.
+   *
+   * @param {string} method - the HTTP method
+   * @param {string} queryString - the URI path and GET parameters
+   * @param {string} body - an object that will be encoded as JSON in the request body
+   */
   newSignedRequest(method, queryString, body) {
     let requestBody;
     let d = new Date();
-    this.signKey = this.getSignKey(this.secretKey, d);
-    if (body === null) {
+    let signKey = this.getSignKey(this._config.secretKey, d);
+    if (body === null || body === undefined) {
       requestBody = '';
     } else {
       requestBody = JSON.stringify(body);
     }
     queryString = '/' + this._config.apiVersionMajor + queryString;
     let aStr = this.getAuthenticationString(method, queryString, d.toISOString(), requestBody);
-    let sig = this.sign(this.signKey, 'binary', aStr, 'hex');
-
+    let rqstSig = this.sign(signKey, 'binary', aStr, 'hex');
     let hdrs = new Headers({
-      "Content-Type": "application/json; charset=utf-8",
+      "Content-Type": "application/json",
       "Content-Length": Buffer.byteLength(requestBody),
-      "User-Agent": "Backend.AI Client for Javascript " + this.clientVersion,
-      'X-BackendAI-Version': this._config.apiVersion,
+      "User-Agent": `Backend.AI Client for Javascript ${this.mangleUserAgentSignature()}`,
+      "X-BackendAI-Version": this._config.apiVersion,
       "X-BackendAI-Date": d.toISOString(),
-      "Authorization": `Sorna signMethod=HMAC-SHA256, credential=${this.accessKey}:${sig}`
+      "Authorization": `BackendAI signMethod=HMAC-SHA256, credential=${this._config.accessKey}:${rqstSig}`
     });
 
     let requestInfo = {
@@ -168,12 +227,16 @@ class BackendAIClient {
     return requestInfo;
   }
 
+  /**
+   * Same to newRequest() method but it does not sign the request.
+   * Use this for unauthorized public APIs.
+   */
   newUnsignedRequest(method, queryString, body) {
     let d = new Date();
     let hdrs = new Headers({
       "Content-Type": "application/json",
-      "User-Agent": "Backend.AI Client for Javascript " + this.clientVersion,
-      'X-BackendAI-Version': this._config.apiVersion,
+      "User-Agent": `Backend.AI Client for Javascript ${this.mangleUserAgentSignature()}`,
+      "X-BackendAI-Version": this._config.apiVersion,
       "X-BackendAI-Date": d.toISOString()
     });
     queryString = '/' + this._config.apiVersionMajor + queryString;
@@ -188,11 +251,13 @@ class BackendAIClient {
   }
 
   getAuthenticationString(method, queryString, dateValue, bodyValue) {
+    let bodyHash = crypto.createHash(this._config.hashType)
+                   .update(bodyValue).digest('hex');
     return (method + '\n' + queryString + '\n' + dateValue + '\n'
-            + 'host:' + this._config.endpoint + '\n'
+            + 'host:' + this._config.endpointHost + '\n'
             + 'content-type:application/json' + '\n'
-            + 'x-backendai-version:'+this._config.apiVersion + '\n'
-            + crypto.createHash(this._config.hashType).update(bodyValue).digest('hex'));
+            + 'x-backendai-version:' + this._config.apiVersion + '\n'
+            + bodyHash);
   }
 
   getCurrentDate(now) {
@@ -205,19 +270,30 @@ class BackendAIClient {
 
   sign(key, key_encoding, msg, digest_type) {
     let kbuf = new Buffer(key, key_encoding);
-    let hmac = crypto.createHmac(this.hash_type, kbuf);
+    let hmac = crypto.createHmac(this._config.hashType, kbuf);
     hmac.update(msg, 'utf8');
     return hmac.digest(digest_type);
   }
 
   getSignKey(secret_key, now) {
     let k1 = this.sign(secret_key, 'utf8', this.getCurrentDate(now), 'binary');
-    let k2 = this.sign(k1, 'binary', this.endpoint, 'binary');
+    let k2 = this.sign(k1, 'binary', this._config.endpointHost, 'binary');
     return k2;
   }
 }
 
+const backend = {
+  Client: Client,
+  ClientConfig: ClientConfig,
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports.BackendAIClient = BackendAIClient;
-  module.exports.BackendAIConfig = BackendAIConfig;
+  // for use like "ai.backend.Client"
+  module.exports.backend = backend;
+  // for classical uses
+  module.exports.Client = Client;
+  module.exports.ClientConfig = ClientConfig;
+  // legacy aliases
+  module.exports.BackendAIClient = Client;
+  module.exports.BackendAIClientConfig = ClientConfig;
 }

--- a/backend.ai-client.js
+++ b/backend.ai-client.js
@@ -77,7 +77,7 @@ class Client {
   /**
    * The client API wrapper.
    *
-   * @param {BackendAIConfig} config - the API client-side configuration
+   * @param {ClientConfig} config - the API client-side configuration
    * @param {string} agentSignature - an extra string that will be appended to User-Agent headers when making API requests
    */
   constructor(config, agentSignature) {

--- a/backend.ai-client.js
+++ b/backend.ai-client.js
@@ -80,7 +80,7 @@ class BackendAIClient {
   }
 
   getAPIversion() {
-    let rqst = this.newUnsignedRequest('GET', '/');
+    let rqst = this.newUnsignedRequest('GET', '/', null);
     return fetch(rqst.uri, rqst)
     .then( function(response) {
       if (response.version) {
@@ -91,10 +91,12 @@ class BackendAIClient {
     });
   }
 
-  createKernel(kernelType) {
+  createKernel(kernelType, clientSessionToken) {
+    if (typeof clientSessionToken == 'undefined')
+      clientSessionToken = "backend-ai-live-code-runner";
     let requestBody = {
       "lang": kernelType,
-      "clientSessionToken": "backend-ai-live-code-runner",
+      "clientSessionToken": clientSessionToken,
       "resourceLimits": {
         "maxMem": 0,
         "timeout": 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend.ai-client",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Backend.AI Client for javascript",
   "main": "backend.ai-client.js",
   "scripts": {
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/lablup/backend.ai-client-js/issues"
   },
-  "homepage": "https://github.com/lablup/backend.ai-client-js#readme",
+  "homepage": "https://github.com/lablup/backend.ai-client-js",
   "dependencies": {
     "node-fetch": "^1.6.3"
   },


### PR DESCRIPTION
 * Add an explicit `ClientConfig` class to read environment variables or manually pass settings: access key, secret key, and endpint URL.
 * Abstract all `fetch()` calls so that the user-side codes do not have to repeat JSON parsing and exception handling at various levels. Also add explicit static constants for error types (`ERR_SERVER`, `ERR_RESPONSE`, `ERR_REQUEST`).
 * Prettify import chain so that we can now use `ai.backend.Client`.
 * Add JSDoc-style comments to major APIs.
 * Allow user-side codes to add an extra `User-Agent` signature string (e.g., VSCode plugin can add VSCode version and the plugin version)
 * Apply ES6 arrow functions more aggressively to avoid clutters like `let parentObj = this`.
 * Clearly state that this code runs on ES6-compatible runtimes.
 * Bump version to 0.2.0 and add README