### PR TITLE
Docs: fix yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install backend.ai-client
 You can also use `yarn`.
 
 ```console
-$ yarn install backend.ai-client
+$ yarn add backend.ai-client
 ```
 
 ## Build


### PR DESCRIPTION
Yarn uses 'add' rather than 'install' to add dependencies